### PR TITLE
clean up git folder after dapp creation

### DIFF
--- a/helpers/utils/cleanUpFiles.ts
+++ b/helpers/utils/cleanUpFiles.ts
@@ -42,4 +42,8 @@ export const cleanUpFiles = () => {
     recursive: true,
     force: true,
   });
+  fs.rmSync(path.join(process.cwd(), ".git"), {
+    recursive: true,
+    force: true,
+  });
 };


### PR DESCRIPTION
remove the .git folder once dapp is created by `create-web3-dapp`

