### PR TITLE
Fix spacing issue

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,8 @@ import chalk from "chalk";
 import { createEnv } from "./helpers/utils/createEnv.js";
 import { dappInfo } from "./interfaces/dappInfo.js";
 
-console.log(`MMMMMMMMMMMMMMMMMK:..:KMMMMMMMMMMMMMMMMM
+console.log(`
+MMMMMMMMMMMMMMMMMK:..:KMMMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMMWO,    ,OWMMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMWk'      'kWMMMMMMMMMMMMMM
 MMMMMMMMMMMMMMK;        .dNMMMMMMMMMMMMM
@@ -29,7 +30,8 @@ MMWO,       .cXMXkxxxxxxxxxxxxxxxxxkKWMM
 MWx'       .oNW0;.                  'xWM
 Nd.       .xNWk'                     .dN
 l.       'kWNx.                       .l
-.       .kWM0'                         .`);
+.       .kWM0'                         .
+`);
 
 console.log("\n");
 console.log("🔵 Welcome to the create-web3-dapp wizard 🔵");
@@ -207,7 +209,7 @@ async function run() {
     cleanUpFiles();
 
     console.log(
-      chalk.green("Visit https://docs.alchemy.com/for the complete tutorial")
+      chalk.green("Visit https://docs.alchemy.com/ for the complete tutorial")
     );
   } catch (e) {
     selfDestroy();


### PR DESCRIPTION
When project/dependencies are done, this msg is displayed: `Visit https://docs.alchemy.com/for the complete tutorial` where "for" is part of the link (missing space after the link), so if a user clicks on it, it will get a 404. This PR will fix this issue.