### PR TITLE
README.md correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ cd my-dapp
 8. Run the application
 
 ```sh
-npm run dev
+npm run start
 ```
 
 9. Go to to <a href="localhost:3000">localhost:3000</a>:


### PR DESCRIPTION
Should say `npm run start` not `npm run dev` , as per the scripts section in package.json