### PR TITLE
Fix copyFile function bug

### DIFF
--- a/helpers/utils/cleanUpFiles.ts
+++ b/helpers/utils/cleanUpFiles.ts
@@ -18,9 +18,6 @@ export const cleanUpFiles = () => {
 	fs.rmSync(path.join(process.cwd(), ".eslintignore"), {
 		force: true,
 	});
-	fs.rmSync(path.join(process.cwd(), ".eslintrc"), {
-		force: true,
-	});
 	fs.rmSync(path.join(process.cwd(), "contributing.md"), {
 		force: true,
 	});
@@ -43,7 +40,7 @@ export const cleanUpFiles = () => {
 		force: true,
 	});
 	fs.rmSync(path.join(process.cwd(), ".git"), {
-	        recursive: true,
-	        force: true,
+		recursive: true,
+		force: true,
 	});
 };

--- a/helpers/utils/copyFile.ts
+++ b/helpers/utils/copyFile.ts
@@ -1,13 +1,13 @@
-import path from "path"
-import fse from "fs-extra"
+import path from "path";
+import fse from "fs-extra";
 
 export const copyFile = (folder, filename, destination) => {
+	const file = path.join(process.cwd(), "templates", folder, filename);
 
-    const file = path.join(process.cwd(), "templates", folder, filename)
+	if (destination !== process.cwd()) {
+		destination = path.join(process.cwd(), destination);
+	}
+	destination = path.join(destination, filename);
 
-    if (destination !== process.cwd()) {
-        destination = path.join(process.cwd(), destination)
-    }
-    
-    fse.copySync(file, destination)
-}
+	fse.copySync(file, destination);
+};


### PR DESCRIPTION
### Bugs
1. `copyFile` function on
https://github.com/Eversmile12/create-web3-dapp/blob/92ebc9000d16481ea93388f2c13c3df4f2a46703/helpers/utils/createPackage.ts#L103
https://github.com/Eversmile12/create-web3-dapp/blob/92ebc9000d16481ea93388f2c13c3df4f2a46703/helpers/utils/createPackage.ts#L104
is throwing the following error:
> Error: Cannot overwrite directory 'XXX' with non-directory 'XXX'.

which triggers the `selfDestroy()` and causes the script silently fail.

2. `cleanUpFiles` function removes `.eslintrc` after `copyFile` has copied it.

### Fixes
1. Append the filename to the destination of the `copyFile` function.
2. Remove `.eslintrc` line from `cleanUpFiles` function.